### PR TITLE
refactor: Renamed gdk version and updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+custom-build/
+greengrass-build/
 develop-eggs/
 dist/
 downloads/

--- a/gdk-config.json
+++ b/gdk-config.json
@@ -18,5 +18,5 @@
       }
     }
   },
-  "tools_version": "1.0.0"
+  "gdk_version": "1.0.0"
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Renamed `tools_version` to `gdk_version` as part of cli renaming.
* Updated gitignore to exclude build folders.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
