### PR TITLE
refactor: replaced LATEST with NEXT_PATCH

### DIFF
--- a/gdk-config.json
+++ b/gdk-config.json
@@ -2,14 +2,14 @@
   "component": {
     "aws.greengrass.labs.LocalWebServer": {
       "author": "Amazon",
-      "version": "LATEST",
+      "version": "NEXT_PATCH",
       "build": {
         "build_system": "custom",
         "custom_build_command": [
           "bash",
           "build-custom.sh",
           "aws.greengrass.labs.LocalWebServer",
-          "LATEST"
+          "NEXT_PATCH"
         ]
       },
       "publish": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
With latest changes GDK expects version to be NEXT_PATCH instead of LATEST, so making corresponding change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
